### PR TITLE
[NBS-5] Add CI Checks and Build Status Badge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
+    - name: Cargo Clippy Check
+      run: cargo clippy -- -Dwarnings
+    - name: Code Format Check
+      run: cargo fmt --all -- --check
     - name: Run tests
       run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build Status](https://github.com/N-Body-Project/N-Body-Simulator/actions/workflows/rust.yml/badge.svg?branch=main)
+
 # N-Body-Simulator
 Simulation of gravitational interaction of abstract particles
 


### PR DESCRIPTION
## Summary
- Added `cargo clippy` and `cargo fmt` checks to the GitHub Actions workflow for linting and formatting.
- Included a build status badge in the README to display the CI status for the `main` branch.