### PR TITLE
[NBS-16] feat: add `rayon` dependency for parallel processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ authors = ["Maksym Prymierov <primerovmax@gmail.com>"]
 [dependencies]
 vecmath = "1.0"
 rand = "0.8"
+rayon = "1.10"


### PR DESCRIPTION
- Added `rayon = "1.10"` to `Cargo.toml` to enable parallelism in the project.
- Prepares the project for optimized performance with multithreading capabilities.