### PR TITLE
[NBS-33] Parallelize Force Computation with Rayon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,42 +1,37 @@
 use crate::types::nbodysystem::NBodySystem;
 use crate::types::particle::Particle;
+use std::time::Instant;
 
 pub mod physics;
 pub mod types;
 
 fn main() {
     let mut system = NBodySystem::default();
+    let particle_count: usize = 3;
 
-    const PARTICLE_MASS: f64 = 1.5e14;
-    system.add_particle(Particle::new(
-        0,
-        [-50.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0],
-        PARTICLE_MASS,
-    ));
-    system.add_particle(Particle::new(
-        1,
-        [50.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0],
-        PARTICLE_MASS,
-    ));
-    system.add_particle(Particle::new(
-        2,
-        [100.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0],
-        PARTICLE_MASS,
-    ));
+    for i in 0..particle_count {
+        system.add_particle(Particle::new(
+            i as u64,
+            [i as f64 * 50.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            1.5e14 * (i + 1) as f64,
+        ));
+    }
+
+    let start = Instant::now();
 
     let forces = system.compute_all_forces();
     println!("{forces:?}");
 
-    for (i, force) in forces.iter().enumerate().take(3) {
+    for (i, force) in forces.iter().enumerate().take(particle_count) {
         let p = system.get_particle_by_index(i).expect("REASON");
         p.update_particle_euler(*force, 0.1);
         println!("Velocity result {:?}", p.velocity());
         println!("     Pos result {:?}", p.pos());
     }
+
+    let duration = start.elapsed();
+
+    println!("Total Time: {duration:#?}.");
 }


### PR DESCRIPTION
## Summary
This pull request introduces parallelization of the `compute_all_forces` function in the N-Body simulation using `rayon` to significantly improve performance for larger systems.

## Changes
- Refactored `compute_all_forces` to leverage `rayon` for parallel iteration, reducing execution time.
- Used thread-local storage and `reduce` for efficient merging of intermediate results.
- Updated `.gitignore` to exclude `.idea` files for cleaner repository management.
- Removed unused `vec3_mul` import from `particle.rs`.
- Simplified particle initialization and added timing in `main.rs` to track performance improvements.

## Action Required
Review and merge to enable parallelized force computation and structural enhancements.

## **Dependency**
This pull request depends on the following pull request, which **must be merged first**:
https://github.com/N-Body-Project/N-Body-Simulator/pull/6