### PR TITLE
[NBS-36] Add CLI Support and Output Formatting for N-body Simulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ vecmath = "1.0.0"
 rand = "0.9.2"
 rayon = "1.10.0"
 macroquad = "0.4.14"
+clap = { version = "4.5.41", features = ["derive"] }
+tokio = { version = "1.47.0", features = ["sync", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ clap = { version = "4.5.41", features = ["derive"] }
 tokio = { version = "1.47.0", features = ["sync", "rt-multi-thread"] }
 serde = { version = "1.0.219", features = ["derive"] }
 csv = "1.3.1"
+serde_json = "1.0.141"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ rayon = "1.10.0"
 macroquad = "0.4.14"
 clap = { version = "4.5.41", features = ["derive"] }
 tokio = { version = "1.47.0", features = ["sync", "rt-multi-thread"] }
+serde = { version = "1.0.219", features = ["derive"] }
+csv = "1.3.1"

--- a/src/gui/engine.rs
+++ b/src/gui/engine.rs
@@ -18,23 +18,17 @@ const ZOOM_SENSITIVITY: f32 = 0.0001;
 const PARTICLE_RADIUS: f32 = 2.0;
 const TIME_STEP: f64 = 100.0;
 
-pub struct NBodyEngine {
-    m_system: NBodySystem,
+pub struct NBodyEngine<'a> {
+    m_system: &'a mut NBodySystem,
     m_zoom: f32,
     m_x: f32,
     m_y: f32,
 }
 
-impl Default for NBodyEngine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl NBodyEngine {
-    pub fn new() -> Self {
+impl<'a> NBodyEngine<'a> {
+    pub fn new(nbody_system: &'a mut NBodySystem) -> Self {
         Self {
-            m_system: NBodySystem::default(),
+            m_system: nbody_system,
             m_zoom: DEFAULT_ZOOM,
             m_x: DEFAULT_X,
             m_y: DEFAULT_Y,
@@ -83,7 +77,7 @@ impl NBodyEngine {
             }
 
             if keys_pressed.contains(&KeyCode::R) {
-                self.m_system = NBodySystem::default();
+                self.m_system.remove_all_particles();
             }
 
             let wheel = mouse_wheel().1;

--- a/src/gui/engine.rs
+++ b/src/gui/engine.rs
@@ -11,10 +11,13 @@ use macroquad::prelude::{
 const DEFAULT_ZOOM: f32 = 1000.0;
 const DEFAULT_X: f32 = 1000.0;
 const DEFAULT_Y: f32 = 850.0;
-const CAMERA_MOVE_SPEED: f32 = 1.0;
+const CAMERA_MOVE_SPEED: f32 = 5.0;
 const MIN_ZOOM: f32 = 100.0;
 const MAX_ZOOM: f32 = 10000.0;
-const ZOOM_SENSITIVITY: f32 = 0.0001;
+#[cfg(windows)]
+const ZOOM_SENSITIVITY: f32 = 0.0009;
+#[cfg(unix)]
+const ZOOM_SENSITIVITY: f32 = 0.09;
 const PARTICLE_RADIUS: f32 = 2.0;
 const TIME_STEP: f64 = 100.0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ pub mod types;
 const MASS_CENTRAL: f64 = 1e11;
 const MASS_SECOND: f64 = 5e7;
 const MASS_THIRD: f64 = 5e5;
-const MASS_NEGATIVE: f64 = -1e-16;
+const MASS_FOURTH: f64 = 5e2;
 
 const POS_CENTRAL: [f64; 3] = [1000.0, 500.0, 0.0];
 const POS_SECOND: [f64; 3] = [500.0, 500.0, 0.0];
@@ -64,7 +64,7 @@ async fn main() {
             position,
             PARTICLE_VEL,
             VEL_ZERO,
-            MASS_NEGATIVE,
+            MASS_FOURTH,
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 use crate::gui::engine::NBodyEngine;
+use crate::terminal::cli::NBodyCli;
+use crate::types::nbodysystem::NBodySystem;
 use crate::types::particle::Particle;
 
 pub mod gui;
 pub mod physics;
+mod terminal;
 pub mod types;
 
 const MASS_CENTRAL: f64 = 1e11;
@@ -26,7 +29,12 @@ const PARTICLE_VEL: [f64; 3] = [0.1, 0.0, 0.0];
 
 #[macroquad::main("N Body Problem")]
 async fn main() {
-    let mut engine = NBodyEngine::new();
+    let mut system = NBodySystem::default();
+
+    let mut cli = NBodyCli::new(&mut system);
+    cli.handle_args().await;
+
+    let mut engine = NBodyEngine::new(&mut system);
 
     engine.add_particle(Particle::new(
         0,

--- a/src/terminal/cli.rs
+++ b/src/terminal/cli.rs
@@ -2,13 +2,23 @@ use crate::types::nbodysystem::NBodySignal;
 use crate::types::nbodysystem::NBodySystem;
 use crate::types::particle::Particle;
 use clap::Parser;
+use serde::Serialize;
+use std::fs::File;
+use std::io::Write;
+
+#[derive(Serialize)]
+struct ParticleData {
+    id: u64,
+    position: [f64; 3],
+    velocity: [f64; 3],
+}
 
 /// N Body Problem
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
     /// Select the type of data output
-    #[arg(short, long, default_value = "none", value_parser = [ "none", "terminal", "plain_text", "csv"])]
+    #[arg(short, long, default_value = "none", value_parser = [ "none", "terminal", "plain_text", "csv", "json"])]
     output: String,
 
     /// Limit the output of information about particles to once every N steps
@@ -54,6 +64,10 @@ impl<'a> NBodyCli<'a> {
                         }
                         "csv" => {
                             let writer = create_csv_writer();
+                            writer(&particles, &file_name);
+                        }
+                        "json" => {
+                            let writer = create_json_writer();
                             writer(&particles, &file_name);
                         }
                         _ => println!("Incorrect output type"),
@@ -129,5 +143,24 @@ fn create_csv_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
         }
 
         csv_output.flush().expect("Unable to flush file");
+    }
+}
+
+fn create_json_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
+    move |particles: &Vec<Particle>, file_name: &String| {
+        println!("Write to file: {file_name}");
+        let particles_data: Vec<ParticleData> = particles
+            .iter()
+            .map(|particle| ParticleData {
+                id: particle.id(),
+                position: particle.pos(),
+                velocity: particle.velocity(),
+            })
+            .collect();
+
+        let json = serde_json::to_string_pretty(&particles_data).expect("Unable to serialize");
+        let mut file = File::create(file_name).expect("Unable to create file");
+        file.write_all(json.as_bytes())
+            .expect("Unable to write to file");
     }
 }

--- a/src/terminal/cli.rs
+++ b/src/terminal/cli.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 #[command(version, about, long_about = None)]
 pub struct Args {
     /// Select the type of data output
-    #[arg(short, long, default_value = "none", value_parser = [ "none", "terminal", "plain_text"])]
+    #[arg(short, long, default_value = "none", value_parser = [ "none", "terminal", "plain_text", "csv"])]
     output: String,
 
     /// Limit the output of information about particles to once every N steps
@@ -52,6 +52,10 @@ impl<'a> NBodyCli<'a> {
                             let writer = create_plain_text_writer();
                             writer(&particles, &file_name);
                         }
+                        "csv" => {
+                            let writer = create_csv_writer();
+                            writer(&particles, &file_name);
+                        }
                         _ => println!("Incorrect output type"),
                     },
                 }
@@ -87,5 +91,43 @@ fn create_plain_text_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
             .as_str();
         }
         std::fs::write(file_name.as_str(), output).expect("Unable to write to file");
+    }
+}
+
+fn create_csv_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
+    move |particles: &Vec<Particle>, file_name: &String| {
+        println!("Write to file: {file_name}");
+        let mut csv_output = csv::Writer::from_path(file_name).expect("Unable to create file");
+
+        csv_output
+            .write_record([
+                "ID",
+                "Position_X",
+                "Position_Y",
+                "Position_Z",
+                "Velocity_X",
+                "Velocity_Y",
+                "Velocity_Z",
+            ])
+            .expect("Unable to write header");
+
+        for particle in particles {
+            let pos = particle.pos();
+            let vel = particle.velocity();
+
+            csv_output
+                .write_record(&[
+                    particle.id().to_string(),
+                    pos[0].to_string(),
+                    pos[1].to_string(),
+                    pos[2].to_string(),
+                    vel[0].to_string(),
+                    vel[1].to_string(),
+                    vel[2].to_string(),
+                ])
+                .expect("Unable to write record");
+        }
+
+        csv_output.flush().expect("Unable to flush file");
     }
 }

--- a/src/terminal/cli.rs
+++ b/src/terminal/cli.rs
@@ -1,18 +1,23 @@
 use crate::types::nbodysystem::NBodySignal;
 use crate::types::nbodysystem::NBodySystem;
+use crate::types::particle::Particle;
 use clap::Parser;
 
 /// N Body Problem
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Print the velocities and coordinates
-    #[arg(short, long)]
-    output: bool,
+    /// Select the type of data output
+    #[arg(short, long, default_value = "none", value_parser = [ "none", "terminal", "plain_text"])]
+    output: String,
 
     /// Limit the output of information about particles to once every N steps
     #[arg(short, long, default_value_t = 1000)]
     limit: u16,
+
+    /// Set a file name to save the results
+    #[arg(short, long, default_value = "output.txt")]
+    file: String,
 }
 
 pub struct NBodyCli<'a> {
@@ -30,26 +35,57 @@ impl<'a> NBodyCli<'a> {
 
     pub async fn handle_args(&mut self) {
         self.m_n_body_system.set_limit(self.m_args.limit);
+        let mut receiver = self.m_n_body_system.subscribe();
+        let file_name = self.m_args.file.clone();
+        let output_type = self.m_args.output.clone();
 
-        if self.m_args.output {
-            let mut receiver = self.m_n_body_system.subscribe();
-
-            std::thread::spawn(move || {
-                while let Ok(signal) = receiver.blocking_recv() {
-                    match signal {
-                        NBodySignal::LimitReached { particles } => {
-                            for particle in particles {
-                                println!(
-                                    "Particle: [{}] POS: {:?}; Velocity: {:?};",
-                                    particle.id(),
-                                    particle.pos(),
-                                    particle.velocity()
-                                );
-                            }
+        std::thread::spawn(move || {
+            while let Ok(signal) = receiver.blocking_recv() {
+                match signal {
+                    NBodySignal::LimitReached { particles } => match output_type.as_str() {
+                        "none" => {}
+                        "terminal" => {
+                            let writer = create_terminal_writer();
+                            writer(&particles);
                         }
-                    }
+                        "plain_text" => {
+                            let writer = create_plain_text_writer();
+                            writer(&particles, &file_name);
+                        }
+                        _ => println!("Incorrect output type"),
+                    },
                 }
-            });
+            }
+        });
+    }
+}
+
+fn create_terminal_writer() -> impl Fn(&Vec<Particle>) + Send {
+    move |particles: &Vec<Particle>| {
+        for particle in particles {
+            println!(
+                "Particle: [{}] POS: {:?}; Velocity: {:?};",
+                particle.id(),
+                particle.pos(),
+                particle.velocity()
+            );
         }
+    }
+}
+
+fn create_plain_text_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
+    move |particles: &Vec<Particle>, file_name: &String| {
+        let mut output = String::new();
+        println!("Write to file: {file_name}");
+        for particle in particles {
+            output += format!(
+                "Particle: [{}] POS: {:?}; Velocity: {:?};\n",
+                particle.id(),
+                particle.pos(),
+                particle.velocity()
+            )
+            .as_str();
+        }
+        std::fs::write(file_name.as_str(), output).expect("Unable to write to file");
     }
 }

--- a/src/terminal/cli.rs
+++ b/src/terminal/cli.rs
@@ -1,0 +1,55 @@
+use crate::types::nbodysystem::NBodySignal;
+use crate::types::nbodysystem::NBodySystem;
+use clap::Parser;
+
+/// N Body Problem
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Print the velocities and coordinates
+    #[arg(short, long)]
+    output: bool,
+
+    /// Limit the output of information about particles to once every N steps
+    #[arg(short, long, default_value_t = 1000)]
+    limit: u16,
+}
+
+pub struct NBodyCli<'a> {
+    m_args: Args,
+    m_n_body_system: &'a mut NBodySystem,
+}
+
+impl<'a> NBodyCli<'a> {
+    pub fn new(n_body_system: &'a mut NBodySystem) -> Self {
+        Self {
+            m_args: Args::parse(),
+            m_n_body_system: n_body_system,
+        }
+    }
+
+    pub async fn handle_args(&mut self) {
+        self.m_n_body_system.set_limit(self.m_args.limit);
+
+        if self.m_args.output {
+            let mut receiver = self.m_n_body_system.subscribe();
+
+            std::thread::spawn(move || {
+                while let Ok(signal) = receiver.blocking_recv() {
+                    match signal {
+                        NBodySignal::LimitReached { particles } => {
+                            for particle in particles {
+                                println!(
+                                    "Particle: [{}] POS: {:?}; Velocity: {:?};",
+                                    particle.id(),
+                                    particle.pos(),
+                                    particle.velocity()
+                                );
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,0 +1,1 @@
+pub mod cli;

--- a/src/types/nbodysystem.rs
+++ b/src/types/nbodysystem.rs
@@ -66,7 +66,11 @@ impl NBodySystem {
     }
 
     pub fn remove_particle_by_index(&mut self, index: usize) {
-        self.m_particles.remove(index);
+        if index < self.m_particles.len() {
+            self.m_particles.remove(index);
+        } else {
+            println!("Index out of bounds");
+        }
     }
 
     pub fn remove_all_particles(&mut self) {

--- a/src/types/nbodysystem.rs
+++ b/src/types/nbodysystem.rs
@@ -1,14 +1,38 @@
 use super::particle::Particle;
 use crate::physics::gravity::gravitational_force;
 use rayon::prelude::*;
+use tokio::sync::broadcast;
 use vecmath::{Vector3, vec3_add, vec3_neg};
 
-#[derive(Default)]
+#[derive(Clone)]
+pub enum NBodySignal {
+    LimitReached { particles: Vec<Particle> },
+}
+
 pub struct NBodySystem {
     m_particles: Vec<Particle>,
+    m_limit: u16,
+    m_step: u16,
+    signal_sender: broadcast::Sender<NBodySignal>,
+}
+
+impl Default for NBodySystem {
+    fn default() -> Self {
+        let (sender, _) = broadcast::channel(16);
+        Self {
+            m_particles: Vec::new(),
+            m_limit: 1000,
+            m_step: 0,
+            signal_sender: sender,
+        }
+    }
 }
 
 impl NBodySystem {
+    pub fn subscribe(&self) -> broadcast::Receiver<NBodySignal> {
+        self.signal_sender.subscribe()
+    }
+
     pub fn add_particle(&mut self, particle: Particle) {
         self.m_particles.push(particle);
     }
@@ -45,6 +69,10 @@ impl NBodySystem {
         self.m_particles.remove(index);
     }
 
+    pub fn remove_all_particles(&mut self) {
+        self.m_particles.clear();
+    }
+
     pub fn len(&self) -> usize {
         self.m_particles.len()
     }
@@ -53,11 +81,12 @@ impl NBodySystem {
         self.m_particles.is_empty()
     }
 
-    pub fn compute_all_forces(&self) -> Vec<Vector3<f64>> {
+    pub fn compute_all_forces(&mut self) -> Vec<Vector3<f64>> {
         if self.m_particles.is_empty() {
-            println!("No particles in system");
             return Default::default();
         }
+
+        self.check_limit_reached();
 
         let particle_count = self.m_particles.len();
 
@@ -97,5 +126,26 @@ impl NBodySystem {
                     acc
                 },
             )
+    }
+
+    pub fn set_limit(&mut self, limit: u16) {
+        self.m_limit = limit;
+    }
+
+    fn check_limit_reached(&mut self) {
+        self.m_step += 1;
+        if self.m_step >= self.m_limit {
+            self.m_step = 0;
+
+            let particles_copy = self
+                .m_particles
+                .par_iter()
+                .map(|p| p.clone())
+                .collect::<Vec<_>>();
+
+            let _ = self.signal_sender.send(NBodySignal::LimitReached {
+                particles: particles_copy,
+            });
+        }
     }
 }

--- a/src/types/particle.rs
+++ b/src/types/particle.rs
@@ -1,6 +1,6 @@
 use vecmath::{Vector3, vec3_add, vec3_scale};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Particle {
     m_id: u64,
     m_position: Vector3<f64>,


### PR DESCRIPTION
## Overview
This pull request introduces comprehensive CLI support and flexible output formatting options for the N-body simulation. It enables headless execution, debugging, and integration with external systems through human-readable or structured data formats.

## Key Features and Changes
### CLI Integration
- Introduced `clap` for parsing command-line arguments.
- Added `--output (-o)` flag to choose output mode: `none`, `plain_tex`t, `csv`, `json`.
- Added `--file` flag to redirect output to a file (e.g., `output.txt`, `output.csv`, etc.).
- Added `--limit (-l)` flag to set the output interval (default: every 1000 steps).
### System Refactor
- Refactored `NBodyEngine` to accept an external `NBodySystem`.
- Shared `NBodySystem` instance between CLI and GUI to maintain state consistency.
- Replaced internal system reset logic with in-place particle reset.
- Added atomic step tracking using `AtomicU16`.
### Output Modes
- **Plain Text**: Human-readable format, printed to console or file.
- **CSV**: Structured tabular format using `serde` and `csv` crate, written to `output.csv`.
- **JSON**: Hierarchical structured output using `serde_json`, written to `output.json`.
### Other Improvements
- Updated `.gitignore` to exclude temporary output files like output.txt.
- Added fallback message for unknown output formats.

## Motivation
These improvements significantly enhance usability for diagnostics, automation, and data export scenarios. Users can now:
- Export particle data for analysis or visualization.
- Choose appropriate formats for integration with data pipelines.

## Tested Scenarios
- CLI runs with each output format (`plain_text`, `csv`, `json`)
- Output redirection to file\
- No output mode (`none`)
- Step-limited output with `--limit`