### PR TITLE
[NBS-45] feat: initialize NBodySystem from Vec<Particle>

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,44 +29,44 @@ const PARTICLE_VEL: [f64; 3] = [0.1, 0.0, 0.0];
 
 #[macroquad::main("N Body Problem")]
 async fn main() {
-    let mut system = NBodySystem::default();
+    let mut particles = Vec::with_capacity(PARTICLE_COUNT + 3);
 
-    let mut cli = NBodyCli::new(&mut system);
-    cli.handle_args().await;
-
-    let mut engine = NBodyEngine::new(&mut system);
-
-    engine.add_particle(Particle::new(
+    particles.push(Particle::new(
         0,
         POS_CENTRAL,
         VEL_ZERO,
         VEL_ZERO,
         MASS_CENTRAL,
     ));
-    engine.add_particle(Particle::new(
+    particles.push(Particle::new(
         1,
         POS_SECOND,
         VEL_SECOND,
         VEL_ZERO,
         MASS_SECOND,
     ));
-    engine.add_particle(Particle::new(2, POS_THIRD, VEL_THIRD, VEL_ZERO, MASS_THIRD));
+    particles.push(Particle::new(2, POS_THIRD, VEL_THIRD, VEL_ZERO, MASS_THIRD));
 
-    for i in 0..PARTICLE_COUNT {
+    particles.extend((3..PARTICLE_COUNT).map(|i| {
         let position = [
             PARTICLE_START_X + (i as f64 * PARTICLE_SPACING),
             PARTICLE_Y,
             0.0,
         ];
-
-        engine.add_particle(Particle::new(
-            (i + 3).try_into().unwrap(),
+        Particle::new(
+            i.try_into().unwrap(),
             position,
             PARTICLE_VEL,
             VEL_ZERO,
             MASS_FOURTH,
-        ));
-    }
+        )
+    }));
+    let mut system: NBodySystem = particles.into();
+
+    let mut cli = NBodyCli::new(&mut system);
+    cli.handle_args().await;
+
+    let mut engine = NBodyEngine::new(&mut system);
 
     engine.update().await;
 }

--- a/src/types/nbodysystem.rs
+++ b/src/types/nbodysystem.rs
@@ -28,6 +28,18 @@ impl Default for NBodySystem {
     }
 }
 
+impl From<Vec<Particle>> for NBodySystem {
+    fn from(m_particles: Vec<Particle>) -> Self {
+        let (sender, _) = broadcast::channel(16);
+        Self {
+            m_limit: m_particles.len() as u16,
+            m_particles,
+            m_step: 0,
+            signal_sender: sender,
+        }
+    }
+}
+
 impl NBodySystem {
     pub fn subscribe(&self) -> broadcast::Receiver<NBodySignal> {
         self.signal_sender.subscribe()


### PR DESCRIPTION
- Replaced `NBodySystem::default()` initialization with a `Vec<Particle>` builder pattern.
- Added `From<Vec<Particle>> for NBodySystem` implementation to allow direct conversion.
- Moved particle creation logic into vector population before system initialization.
- Used `Vec::extend` with iterator mapping to bulk-add generated particles.
- Maintained CLI and engine initialization after system creation for consistent behavior.