### PR TITLE
docs: add Rustdoc comments for core modules

### DIFF
--- a/src/gui/engine.rs
+++ b/src/gui/engine.rs
@@ -8,19 +8,48 @@ use macroquad::prelude::{
     clear_background, draw_circle, next_frame, screen_height, screen_width, set_fullscreen,
 };
 
+// --- Configuration parameters (rendering / integration) ---
+// These are internal constants; adjust to tune the visualization.
+
+// Default camera zoom and target position in world coordinates.
 const DEFAULT_ZOOM: f32 = 1000.0;
 const DEFAULT_X: f32 = 1000.0;
 const DEFAULT_Y: f32 = 850.0;
+
+// Camera panning speed factor (scaled by current zoom & screen size).
 const CAMERA_MOVE_SPEED: f32 = 5.0;
+
+// Zoom bounds (smaller -> more zoom-in).
 const MIN_ZOOM: f32 = 100.0;
 const MAX_ZOOM: f32 = 10000.0;
+
+// Scroll-wheel zoom sensitivity (platform-specific).
 #[cfg(windows)]
 const ZOOM_SENSITIVITY: f32 = 0.0009;
 #[cfg(unix)]
 const ZOOM_SENSITIVITY: f32 = 0.09;
+
+// Radius of drawn particles in pixels.
 const PARTICLE_RADIUS: f32 = 2.0;
+
+/// Integration time step `dt` (simulation seconds per frame).
+///
+/// This is the **configuration parameter** that controls stability/accuracy of
+/// the explicit Euler update used by `Particle::update_particle_euler`.
+/// Larger values advance time faster but can cause instability or energy drift.
 const TIME_STEP: f64 = 100.0;
 
+/// Real-time visualization and driver for an [`NBodySystem`].
+///
+/// `NBodyEngine` owns a mutable reference to the system, exposes a minimal camera
+/// (pan with **W/A/S/D**, zoom with mouse wheel), and advances the simulation
+/// once per frame with a fixed time step (`TIME_STEP`).
+///
+/// UI bindings:
+/// - **Space**: add a random particle
+/// - **R**:     remove all particles
+/// - **W/A/S/D**: pan camera
+/// - Mouse wheel: zoom (clamped to `[MIN_ZOOM, MAX_ZOOM]`)
 pub struct NBodyEngine<'a> {
     m_system: &'a mut NBodySystem,
     m_zoom: f32,
@@ -29,6 +58,9 @@ pub struct NBodyEngine<'a> {
 }
 
 impl<'a> NBodyEngine<'a> {
+    /// Creates a new engine bound to an existing [`NBodySystem`].
+    ///
+    /// Camera starts at (`DEFAULT_X`, `DEFAULT_Y`) with `DEFAULT_ZOOM`.
     pub fn new(nbody_system: &'a mut NBodySystem) -> Self {
         Self {
             m_system: nbody_system,
@@ -38,19 +70,36 @@ impl<'a> NBodyEngine<'a> {
         }
     }
 
+    /// Adds a particle to the underlying system.
     pub fn add_particle(&mut self, particle: Particle) {
         self.m_system.add_particle(particle);
     }
 
+    /// Adds a randomly initialized particle to the system.
+    ///
+    /// See [`Particle::generate_random`] for sampling details.
     pub fn add_random_particle(&mut self) {
         self.m_system.add_random_particle();
     }
 
+    /// Initializes the fullscreen window and clears the background.
+    ///
+    /// Call this once before entering `update`.
     pub fn create_window(&mut self) {
         set_fullscreen(true);
         clear_background(BLACK);
     }
 
+    /// Main render/update loop.
+    ///
+    /// Per frame:
+    /// 1. Handles input (pan/zoom and hotkeys).
+    /// 2. Sets the `Camera2D` based on current pan/zoom.
+    /// 3. Computes all forces via `NBodySystem::compute_all_forces`.
+    /// 4. Applies a single explicit Euler step with `TIME_STEP`.
+    /// 5. Draws each particle as a white circle at its `(x, y)` world position.
+    ///
+    /// The loop yields to the runtime with `next_frame().await`.
     pub async fn update(&mut self) {
         loop {
             clear_background(BLACK);

--- a/src/physics/gravity.rs
+++ b/src/physics/gravity.rs
@@ -5,10 +5,37 @@ use vecmath::vec3_scale;
 use vecmath::vec3_square_len;
 use vecmath::vec3_sub;
 
-// gravitational constant in SI units
+/// Universal gravitational constant `G` in SI units (m³·kg⁻¹·s⁻²).
+///
+/// Value from CODATA 2018: `6.67430e-11`
 pub const G: f64 = 6.67430e-11;
 
-// The force of interaction between two bodies is directly proportional to the mass of each body F = G * (m1 * m2) / r^2
+/// Computes the gravitational force **on `p1` due to `p2`**.
+///
+/// Uses the inverse-square law:
+/// `F = G * (m1 * m2) / r²` along the direction from `p1` to `p2`.
+///
+/// # Parameters
+/// - `p1`: particle experiencing the force.
+/// - `p2`: source particle applying the gravitational pull.
+///
+/// # Returns
+/// A 3D force vector acting on `p1`. If the two particles occupy the same
+/// position (distance squared `< f64::EPSILON`), returns the zero vector to
+/// avoid division by zero.
+///
+/// # Units
+/// Assumes SI-like units: meters (position), seconds (time), kilograms (mass),
+/// and Newtons for the returned force.
+///
+/// # Notes
+/// - The returned vector satisfies Newton’s third law when used symmetrically:
+///   `F(p1←p2) = -F(p2←p1)`.
+/// - No softening term is applied; extreme masses/close separations may require
+///   a softening strategy in a real simulation to improve stability.
+///
+/// # Complexity
+/// O(1) for a single pair evaluation.
 pub fn gravitational_force(p1: &Particle, p2: &Particle) -> Vector3<f64> {
     // vector from p1 to p2
     let r_vec = vec3_sub::<f64>(p2.pos(), p1.pos());

--- a/src/terminal/cli.rs
+++ b/src/terminal/cli.rs
@@ -30,12 +30,21 @@ pub struct Args {
     file: String,
 }
 
+/// Minimal CLI façade around an [`NBodySystem`].
+///
+/// `NBodyCli` parses CLI args, configures the system (notably the `limit`),
+/// subscribes to [`NBodySignal`] events, and routes emitted particle snapshots
+/// to the selected output sink (terminal, plain text, CSV, or JSON).
 pub struct NBodyCli<'a> {
     m_args: Args,
     m_n_body_system: &'a mut NBodySystem,
 }
 
 impl<'a> NBodyCli<'a> {
+    /// Parses CLI arguments and binds this CLI to a given `NBodySystem`.
+    ///
+    /// The system is borrowed mutably so the CLI can adjust configuration
+    /// (e.g., `limit`) and drive the subscription lifecycle.
     pub fn new(n_body_system: &'a mut NBodySystem) -> Self {
         Self {
             m_args: Args::parse(),
@@ -43,6 +52,21 @@ impl<'a> NBodyCli<'a> {
         }
     }
 
+    /// Applies CLI configuration and spawns a background listener for snapshots.
+    ///
+    /// Behavior:
+    /// - Sets `NBodySystem::set_limit(self.m_args.limit)`.
+    /// - Subscribes to [`NBodySignal::LimitReached`].
+    /// - Spawns a thread that blocks on the receiver and, on each snapshot,
+    ///   writes particle data according to `--output`:
+    ///   - `terminal` → stdout print
+    ///   - `plain_text` → text file (`--file`)
+    ///   - `csv` → CSV file (`--file`)
+    ///   - `json` → JSON file (`--file`)
+    ///
+    /// This function returns immediately; the spawned thread keeps running
+    /// while the receiver is alive. Callers typically drive the simulation by
+    /// invoking `compute_all_forces` in a loop elsewhere.
     pub async fn handle_args(&mut self) {
         self.m_n_body_system.set_limit(self.m_args.limit);
         let mut receiver = self.m_n_body_system.subscribe();
@@ -78,6 +102,9 @@ impl<'a> NBodyCli<'a> {
     }
 }
 
+/// Returns a closure that prints per-particle lines to stdout.
+///
+/// Format: `Particle: [ID] POS: [x,y,z]; Velocity: [vx,vy,vz];`
 fn create_terminal_writer() -> impl Fn(&Vec<Particle>) + Send {
     move |particles: &Vec<Particle>| {
         for particle in particles {
@@ -91,6 +118,9 @@ fn create_terminal_writer() -> impl Fn(&Vec<Particle>) + Send {
     }
 }
 
+/// Returns a closure that writes a simple human-readable text file.
+///
+/// Each line contains a particle id, position and velocity. Overwrites `file_name`.
 fn create_plain_text_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
     move |particles: &Vec<Particle>, file_name: &String| {
         let mut output = String::new();
@@ -108,6 +138,10 @@ fn create_plain_text_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
     }
 }
 
+/// Returns a closure that writes a CSV file with header.
+///
+/// Columns: `ID, Position_X, Position_Y, Position_Z, Velocity_X, Velocity_Y, Velocity_Z`.
+/// Overwrites `file_name`.
 fn create_csv_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
     move |particles: &Vec<Particle>, file_name: &String| {
         println!("Write to file: {file_name}");
@@ -146,6 +180,10 @@ fn create_csv_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
     }
 }
 
+/// Returns a closure that writes a pretty-printed JSON array of particles.
+///
+/// Schema per element: `{ "id": u64, "position": [f64;3], "velocity": [f64;3] }`.
+/// Overwrites `file_name`.
 fn create_json_writer() -> impl Fn(&Vec<Particle>, &String) + Send {
     move |particles: &Vec<Particle>, file_name: &String| {
         println!("Write to file: {file_name}");

--- a/src/types/nbodysystem.rs
+++ b/src/types/nbodysystem.rs
@@ -4,11 +4,27 @@ use rayon::prelude::*;
 use tokio::sync::broadcast;
 use vecmath::{Vector3, vec3_add, vec3_neg};
 
+/// Signals emitted by the n-body system.
+///
+/// Currently used to publish periodic snapshots of the particle set
+/// when the step counter reaches the configured `limit`.
 #[derive(Clone, Debug)]
 pub enum NBodySignal {
+    /// Emitted when the internal step counter reaches `limit`.
+    /// Carries a snapshot (deep copy) of all current particles.
     LimitReached { particles: Vec<Particle> },
 }
 
+/// Parallel n-body container and force calculator.
+///
+/// `NBodySystem` owns a dynamic list of [`Particle`]s and can compute
+/// the net gravitational force acting on each particle using a
+/// pairwise all-pairs algorithm. The computation is parallelized with
+/// Rayon and preserves Newton’s third law by accumulating ±F for each pair.
+///
+/// It also exposes a simple tick counter that emits a [`NBodySignal::LimitReached`]
+/// message via a Tokio `broadcast` channel every `limit` calls to
+/// `compute_all_forces`.
 pub struct NBodySystem {
     m_particles: Vec<Particle>,
     m_limit: u16,
@@ -17,6 +33,10 @@ pub struct NBodySystem {
 }
 
 impl Default for NBodySystem {
+    /// Creates an empty system with:
+    /// - `limit = 1000` steps,
+    /// - step counter set to `0`,
+    /// - broadcast channel capacity of 16 messages.
     fn default() -> Self {
         let (sender, _) = broadcast::channel(16);
         Self {
@@ -29,6 +49,9 @@ impl Default for NBodySystem {
 }
 
 impl From<Vec<Particle>> for NBodySystem {
+    /// Builds a system from an initial particle list.
+    ///
+    /// The `limit` is initialized to `particles.len()` (clamped to `u16`).
     fn from(m_particles: Vec<Particle>) -> Self {
         let (sender, _) = broadcast::channel(16);
         Self {
@@ -41,14 +64,25 @@ impl From<Vec<Particle>> for NBodySystem {
 }
 
 impl NBodySystem {
+    /// Subscribes to system signals.
+    ///
+    /// Returns a `broadcast::Receiver` that will receive
+    /// [`NBodySignal::LimitReached`] once every `limit` calls to
+    /// `compute_all_forces`.
     pub fn subscribe(&self) -> broadcast::Receiver<NBodySignal> {
         self.signal_sender.subscribe()
     }
 
+    /// Appends a particle to the system.
     pub fn add_particle(&mut self, particle: Particle) {
         self.m_particles.push(particle);
     }
 
+    /// Generates and appends a random particle.
+    ///
+    /// Returns the id of the newly inserted particle.
+    ///
+    /// See [`Particle::generate_random`] for sampling details.
     pub fn add_random_particle(&mut self) -> u64 {
         let particle: Particle = Particle::generate_random();
 
@@ -59,12 +93,16 @@ impl NBodySystem {
         part_id
     }
 
+    /// Finds a mutable reference to a particle by its id.
+    ///
+    /// Returns `None` if no particle with such id exists.
     pub fn get_particle_by_id(&mut self, id: u64) -> Option<&mut Particle> {
         self.m_particles
             .iter_mut()
             .find(|particle| particle.id() == id)
     }
 
+    /// Returns a mutable reference to the particle at `index`, if present.
     pub fn get_particle_by_index(&mut self, index: usize) -> Option<&mut Particle> {
         if index >= self.m_particles.len() {
             return None;
@@ -73,10 +111,14 @@ impl NBodySystem {
         Some(&mut self.m_particles[index])
     }
 
+    /// Removes the particle with the specified id (if it exists).
     pub fn remove_particle_by_id(&mut self, id: u64) {
         self.m_particles.retain(|value: &Particle| value.id() != id);
     }
 
+    /// Removes the particle by positional index.
+    ///
+    /// If `index` is out of bounds, this is a no-op (logs to stdout).
     pub fn remove_particle_by_index(&mut self, index: usize) {
         if index < self.m_particles.len() {
             self.m_particles.remove(index);
@@ -85,18 +127,37 @@ impl NBodySystem {
         }
     }
 
+    /// Removes all particles from the system.
     pub fn remove_all_particles(&mut self) {
         self.m_particles.clear();
     }
 
+    /// Returns the number of particles.
     pub fn len(&self) -> usize {
         self.m_particles.len()
     }
 
+    /// Returns `true` if there are no particles.
     pub fn is_empty(&self) -> bool {
         self.m_particles.is_empty()
     }
 
+    /// Computes the net gravitational force on every particle.
+    ///
+    /// # Returns
+    /// A vector `F` of length `self.len()`, where `F[i]` is the net force
+    /// acting on particle `i`. If the system is empty, an empty vector is returned.
+    ///
+    /// # Algorithm
+    /// - Work is split across threads with Rayon.
+    /// - Each worker builds a local force buffer to avoid contention,
+    ///   enforcing Newton’s third law by adding `+F` to `i` and `−F` to `j`
+    ///   for every pair `(i, j)`, `j > i`.
+    /// - Local buffers are reduced (summed) into the final result.
+    ///
+    /// # Events
+    /// Increments an internal step counter and may emit
+    /// [`NBodySignal::LimitReached`] when the configured `limit` is reached.
     pub fn compute_all_forces(&mut self) -> Vec<Vector3<f64>> {
         if self.m_particles.is_empty() {
             return Default::default();
@@ -144,10 +205,25 @@ impl NBodySystem {
             )
     }
 
+    /// Sets the emission limit (in **compute steps**).
+    ///
+    /// After every call to `compute_all_forces`, an internal counter
+    /// is incremented. When the counter reaches `limit`, a
+    /// [`NBodySignal::LimitReached`] is broadcast with a snapshot of
+    /// all particles, and the counter is reset to `0`.
+    ///
+    /// # Configuration
+    /// Treat `limit` as a coarse “output frequency” in units of compute steps.
+    /// For example, if your integrator performs one force evaluation per time
+    /// step `dt`, then signals are emitted approximately every `limit * dt`
+    /// seconds of simulated time.
     pub fn set_limit(&mut self, limit: u16) {
         self.m_limit = limit;
     }
 
+    /// Increments the step counter and emits a snapshot when `limit` is reached.
+    ///
+    /// Not public: called automatically by [`compute_all_forces`].
     fn check_limit_reached(&mut self) {
         self.m_step += 1;
         if self.m_step >= self.m_limit {

--- a/src/types/particle.rs
+++ b/src/types/particle.rs
@@ -1,5 +1,16 @@
 use vecmath::{Vector3, vec3_add, vec3_scale};
 
+/// A single point-mass used in the n-body simulation.
+///
+/// `Particle` stores its unique identifier, kinematic state
+/// (position, velocity, acceleration) and its mass.
+/// Fields are intentionally kept private; use the provided getters
+/// and mutable accessors to read/modify the state.
+///
+/// # Invariants
+/// - `m_mass` must be strictly greater than `0.0`.
+/// - Vectors use a right-handed coordinate system and SI-like units
+///   (meters, seconds, kilograms) unless specified otherwise.
 #[derive(Debug, Clone)]
 pub struct Particle {
     m_id: u64,
@@ -10,6 +21,10 @@ pub struct Particle {
 }
 
 impl Default for Particle {
+    /// Creates a particle with zeroed kinematic state and zero mass.
+    ///
+    /// Note: zero mass is **invalid** for integration; calling
+    /// `update_particle_euler` will panic if `mass <= 0.0`.
     fn default() -> Self {
         Self {
             m_id: 0,
@@ -22,6 +37,18 @@ impl Default for Particle {
 }
 
 impl Particle {
+    /// Constructs a new `Particle`.
+    ///
+    /// If `mass` is negative, it is clamped to a small positive value (0.1)
+    /// and a warning is printed.
+    ///
+    /// # Parameters
+    /// - `id`: stable identifier of the particle.
+    /// - `pos`: initial position vector.
+    /// - `velocity`: initial velocity vector.
+    /// - `acceleration`: initial acceleration vector (not used by Euler step;
+    ///   kept for completeness/diagnostics).
+    /// - `mass`: particle mass; must be `> 0`.
     pub fn new(
         id: u64,
         pos: Vector3<f64>,
@@ -42,6 +69,14 @@ impl Particle {
         }
     }
 
+    /// Generates a particle with random id, position, velocity, and a positive mass.
+    ///
+    /// - `position` and `velocity` components are sampled from `[0, 1)`.
+    /// - `acceleration` is set to zero.
+    /// - `mass` is guaranteed to be positive (currently ends up in `(0, 1)`).
+    ///
+    /// This is intended for quick toy setups and tests rather than
+    /// physically meaningful sampling.
     pub fn generate_random() -> Self {
         let mut rand_pos: Vector3<f64> = Default::default();
         let mut rand_velocity: Vector3<f64> = Default::default();
@@ -68,46 +103,76 @@ impl Particle {
         }
     }
 
+    /// Returns the particle identifier.
     pub fn id(&self) -> u64 {
         self.m_id
     }
 
+    /// Returns the current position vector.
     pub fn pos(&self) -> Vector3<f64> {
         self.m_position
     }
 
+    /// Returns the current velocity vector.
     pub fn velocity(&self) -> Vector3<f64> {
         self.m_velocity
     }
 
+    /// Returns the current acceleration vector.
+    ///
+    /// Note: the basic Euler update implemented here does **not** use
+    /// `m_acceleration`; it is provided for external integrators/diagnostics.
     pub fn acceleration(&self) -> Vector3<f64> {
         self.m_acceleration
     }
 
+    /// Returns the particle mass (`> 0` for valid dynamics).
     pub fn mass(&self) -> f64 {
         self.m_mass
     }
 
+    /// Mutable access to the identifier.
     pub fn id_mut(&mut self) -> &mut u64 {
         &mut self.m_id
     }
 
+    /// Mutable access to the position vector.
     pub fn pos_mut(&mut self) -> &mut Vector3<f64> {
         &mut self.m_position
     }
 
+    /// Mutable access to the velocity vector.
     pub fn velocity_mut(&mut self) -> &mut Vector3<f64> {
         &mut self.m_velocity
     }
 
+    /// Mutable access to the acceleration vector.
     pub fn acceleration_mut(&mut self) -> &mut Vector3<f64> {
         &mut self.m_acceleration
     }
 
+    /// Mutable access to mass.
+    ///
+    /// # Safety
+    /// Setting mass to `<= 0.0` will cause `update_particle_euler` to panic.
     pub fn mass_mut(&mut self) -> &mut f64 {
         &mut self.m_mass
     }
 
+    /// Advances the particle state by a single explicit Euler step using a net force.
+    ///
+    /// The method integrates
+    /// `v(t + dt) = v(t) + (F / m) * dt` and
+    /// `x(t + dt) = x(t) + v(t + dt) * dt` (semi-implicit form for position),
+    /// where `F` is the externally supplied net force acting on the particle.
+    ///
+    /// # Parameters
+    /// - `force`: net force vector applied over the time step.
+    /// - `dt`: integration time step in seconds. **Configuration parameter** —
+    ///   choose small enough to keep the explicit Euler method stable for your forces.
+    ///
+    /// # Panics
+    /// Panics if `mass <= 0.0`.
     pub fn update_particle_euler(&mut self, force: Vector3<f64>, dt: f64) {
         assert!(self.m_mass > 0.0, "mass must be > 0");
         self.m_velocity = vec3_add(


### PR DESCRIPTION
- Documented constants and usage in gui/engine.rs.
- Expanded gravitational_force docs with units, edge cases, and Newton’s 3rd law.
- Added lifecycle and output format docs to NBodyCli.
- Documented NBodySystem methods, signals, and force computation.
- Clarified Particle invariants, constructors, and Euler update behavior.